### PR TITLE
Changed decider for long to DecimalTypeDecider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
+### Fixed
+
+- Fixed guessing and parsing for bigint / long values e.g. `"9223372036854775807"`
+
 ## [0.0.5] - 2019-11-01
 
 ### Fixed

--- a/Tests/BigIntGuessTests.cs
+++ b/Tests/BigIntGuessTests.cs
@@ -1,0 +1,36 @@
+﻿using NUnit.Framework;
+using NUnit.Framework.Constraints;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Text;
+using TypeGuesser;
+using TypeGuesser.Deciders;
+
+namespace Tests
+{
+    class BigIntGuessTests
+    {
+        [Test]
+        public void BigInt_TypeDeciderFactory()
+        {
+            var factory = new TypeDeciderFactory(new CultureInfo("en-US"));
+            
+            // The IDecideTypesForStrings for long should be DecimalTypeDecider
+            Assert.IsTrue(factory.Dictionary[typeof(Int64)] is DecimalTypeDecider);
+            Assert.IsTrue(factory.Dictionary[typeof(long)] is DecimalTypeDecider);
+        }
+
+        [Test]
+        public void BigInt_Parse()
+        {
+            var decider = new DecimalTypeDecider(new CultureInfo("en-US"));
+
+            Assert.AreEqual(100,decider.Parse("100"));
+            Assert.AreEqual(9223372036854775807L,decider.Parse("9223372036854775807"));
+            
+        }
+
+
+    }
+}

--- a/Tests/GuesserTests.cs
+++ b/Tests/GuesserTests.cs
@@ -41,6 +41,7 @@ namespace Tests
         [TestCase("f"    ,typeof(bool),"en-us",1,0,0,false)]
         [TestCase(".t."  ,typeof(bool),"en-us",3,0,0,true)]
         [TestCase(".f."  ,typeof(bool),"en-us",3,0,0,false)]
+        [TestCase("9223372036854775807",typeof(decimal),"en-us",19,19,0,9223372036854775807L)]
         [TestCase("5000"  ,typeof(int),"en-us",4,4,0,5000)]
         [TestCase("5000.010", typeof(decimal), "en-us", 8, 4, 2, 5000.01)]
         [TestCase("5,123.001e-10", typeof(decimal), "en-us", 14, 0,13, 0.0000005123001)] //<=it's string length is 14 because this would be the string value we would need to represent
@@ -196,6 +197,35 @@ namespace Tests
             Assert.AreEqual(typeof(int),t.Guess.CSharpType);
         }
 
+        /// <summary>
+        /// Tests that we can fallback from an int guess to a long guess (which we will treat as decimal when parsing)
+        /// </summary>
+        [Test]
+        public void TestGuesser_IntThenLong()
+        {
+            Guesser t = new Guesser();
+            
+            //we see an int
+            t.AdjustToCompensateForValue("-100");
+
+            //we guess the column contains ints
+            Assert.AreEqual(typeof(int), t.Guess.CSharpType);
+            Assert.AreEqual(4, t.Guess.Width);
+            Assert.AreEqual(3, t.Guess.Size.NumbersBeforeDecimalPlace);
+            Assert.AreEqual(0, t.Guess.Size.NumbersAfterDecimalPlace);
+
+            //we see a long
+            t.AdjustToCompensateForValue("9223372036854775807");
+
+            //we change our estimate to the compatible estimate of 'decimal'
+            Assert.AreEqual(typeof(decimal), t.Guess.CSharpType);
+            Assert.AreEqual(19, t.Guess.Width);
+            Assert.AreEqual(19, t.Guess.Size.NumbersBeforeDecimalPlace);
+            Assert.AreEqual(0, t.Guess.Size.NumbersAfterDecimalPlace);
+            
+            //final estimate is decimal
+            Assert.AreEqual(typeof(decimal),t.Guess.CSharpType);
+        }
 
         [Test]
         public void TestGuesser_IntAnddecimal_MustUsedecimal()

--- a/TypeGuesser/Deciders/DecimalTypeDecider.cs
+++ b/TypeGuesser/Deciders/DecimalTypeDecider.cs
@@ -21,7 +21,7 @@ namespace TypeGuesser.Deciders
         /// Creates new instance that recognizes strings with a decimal point representation
         /// </summary>
         /// <param name="culture"></param>
-        public DecimalTypeDecider(CultureInfo culture) : base(culture,TypeCompatibilityGroup.Numerical,typeof(decimal), typeof(float) , typeof(double))
+        public DecimalTypeDecider(CultureInfo culture) : base(culture,TypeCompatibilityGroup.Numerical,typeof(decimal), typeof(float) , typeof(double),typeof(Int64))
         {
             _decimalIndicator = Culture.NumberFormat.NumberDecimalSeparator.Last();
         }

--- a/TypeGuesser/Deciders/IntTypeDecider.cs
+++ b/TypeGuesser/Deciders/IntTypeDecider.cs
@@ -13,7 +13,7 @@ namespace TypeGuesser.Deciders
         /// Creates a new instance for recognizing whole numbers in string values
         /// </summary>
         /// <param name="culture"></param>
-        public IntTypeDecider(CultureInfo culture) : base(culture,TypeCompatibilityGroup.Numerical, typeof(Int16) , typeof(Int32), typeof(Int64),typeof(byte))
+        public IntTypeDecider(CultureInfo culture) : base(culture,TypeCompatibilityGroup.Numerical, typeof(Int16) , typeof(Int32), typeof(byte))
         {
         }
 


### PR DESCRIPTION
Upstream library fix for https://github.com/HicServices/RDMP/issues/65

This fixes a bug where IntTypeDecider claimed to handle `Int64` but would fail on parsing.  Rather than change it's return type I have removed the claim and put it into `DecimalTypeDecider` instead.