### PR TITLE
Feature/stringspan

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -37,3 +37,19 @@ jobs:
         uses: github/codeql-action/analyze@v3
         with:
           category: "/language:${{ matrix.language }}"
+          upload: false
+          output: sarif-results
+
+      - name: filter-sarif
+        uses: advanced-security/filter-sarif@v1
+        with:
+          patterns: |
+            +**/*
+            -**/*.g.cs
+          input: sarif-results/csharp.sarif
+          output: sarif-results/csharp.sarif
+
+      - name: Upload SARIF
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: sarif-results/csharp.sarif

--- a/PACKAGES.md
+++ b/PACKAGES.md
@@ -9,7 +9,5 @@
 
 | Package | Source Code | License | Purpose | Additional Risk Assessment |
 | ------- | ------------| ------- | ------- | -------------------------- |
-| Microsoft.SourceLink.GitHub | [GitHub](https://github.com/dotnet/sourcelink) | [MIT](https://opensource.org/licenses/MIT) | Enable source linkage from nupkg | Official MS project |
-| UniversalTypeConverter | [GitHub](https://github.com/t-bruning/UniversalTypeConverter) | [MS-PL](https://github.com/t-bruning/UniversalTypeConverter/blob/master/LICENSE.md) | Parsing of individual strings into specific target types |  |
 
-
+None - TypeGuesser is now a self-contained pure .Net library!

--- a/Tests/GuesserTests.cs
+++ b/Tests/GuesserTests.cs
@@ -54,8 +54,8 @@ public sealed class GuesserTests
     [TestCase("5.000.000", typeof(string), "en-us", 9, 0, 0, "5.000.000")] //germans swap commas and dots so this is an illegal number
     [TestCase("5,000,000", typeof(string), "de-de", 9, 0, 0, "5,000,000")] //germans swap commas and dots so this is an illegal number
     [TestCase("5,000", typeof(int), "de-de", 5, 1,0,5)] //germans swap commas and dots
-
-    public void Test_OneString_IsType(string guessFor, Type expectedGuess, string culture,int expectedStringLength, int expectedBefore,int expectedAfter,object expectedParseValue)
+    public void Test_OneString_IsType(string guessFor, Type expectedGuess, string culture, int expectedStringLength,
+        int expectedBefore, int expectedAfter, object expectedParseValue)
     {
         var cultureInfo = new CultureInfo(culture);
         var guesser = new Guesser {Culture = cultureInfo};

--- a/Tests/PerformanceTests.cs
+++ b/Tests/PerformanceTests.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Globalization;
 using NUnit.Framework;
-using TB.ComponentModel;
 using TypeGuesser;
 using TypeGuesser.Deciders;
 

--- a/Tests/PerformanceTests.cs
+++ b/Tests/PerformanceTests.cs
@@ -25,8 +25,7 @@ public sealed class PerformanceTests
 
         var decider = new DecimalTypeDecider(new CultureInfo("en-GB"));
 
-        // ReSharper disable once NullableWarningSuppressionIsUsed - this is just for benchmarking
-        var req = new DatabaseTypeRequest(null!);
+        var req = new DatabaseTypeRequest(typeof(bool)) { Unicode = true };
 
         var sw = new Stopwatch();
 

--- a/Tests/PerformanceTests.cs
+++ b/Tests/PerformanceTests.cs
@@ -56,17 +56,6 @@ public sealed class PerformanceTests
         Console.WriteLine($"Guesser.AdjustToCompensateForValue:{sw.ElapsedMilliseconds} ms");
 
 
-        sw.Restart();
-
-        foreach (var s in inputs)
-        {
-            s.To<decimal>(culture);
-        }
-
-        sw.Stop();
-
-        Console.WriteLine($"To<decimal>:{sw.ElapsedMilliseconds} ms");
-
 
         sw.Restart();
 

--- a/TypeGuesser/Deciders/BoolTypeDecider.cs
+++ b/TypeGuesser/Deciders/BoolTypeDecider.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Globalization;
+using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
+using TB.ComponentModel;
 
 namespace TypeGuesser.Deciders;
 
@@ -18,7 +20,13 @@ public sealed partial class BoolTypeDecider(CultureInfo culture) : DecideTypesFo
     /// <inheritdoc/>
     protected override IDecideTypesForStrings CloneImpl(CultureInfo newCulture)
     {
-        return  new BoolTypeDecider(newCulture);
+        return new BoolTypeDecider(newCulture);
+    }
+
+    /// <inheritdoc />
+    protected override object? ParseImpl(ReadOnlySpan<char> value)
+    {
+        return value.Length > 1 && "1tTyYjJ".IndexOf(value[0]) != -1;
     }
 
     /// <inheritdoc/>
@@ -28,7 +36,20 @@ public sealed partial class BoolTypeDecider(CultureInfo culture) : DecideTypesFo
         if (!Settings.CharCanBeBoolean && SingleCharacter.IsMatch(candidateString))
             return false;
 
-        return base.IsAcceptableAsTypeImpl(candidateString, size);
+        return candidateString.Length switch
+        {
+            1 => "1tTyYjJ0fFnN".IndexOf(candidateString[0]) != -1,
+            2 => candidateString.Equals("ja", StringComparison.OrdinalIgnoreCase) ||
+                 candidateString.Equals("no", StringComparison.OrdinalIgnoreCase) ||
+                 candidateString.Equals("-1", StringComparison.OrdinalIgnoreCase),
+            3 => candidateString.Equals("yes", StringComparison.OrdinalIgnoreCase) ||
+                 candidateString.Equals(".t.", StringComparison.OrdinalIgnoreCase) ||
+                 candidateString.Equals(".f.", StringComparison.OrdinalIgnoreCase),
+            4 => candidateString.Equals("true", StringComparison.OrdinalIgnoreCase) ||
+                 candidateString.Equals("nein", StringComparison.OrdinalIgnoreCase),
+            5 => candidateString.Equals("false", StringComparison.OrdinalIgnoreCase),
+            _ => false
+        };
     }
 
     [GeneratedRegex(@"^\s*[A-Za-z]\s*$",RegexOptions.CultureInvariant)]

--- a/TypeGuesser/Deciders/BoolTypeDecider.cs
+++ b/TypeGuesser/Deciders/BoolTypeDecider.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 using System.Text.RegularExpressions;
 
 namespace TypeGuesser.Deciders;
@@ -21,7 +22,7 @@ public sealed partial class BoolTypeDecider(CultureInfo culture) : DecideTypesFo
     }
 
     /// <inheritdoc/>
-    protected override bool IsAcceptableAsTypeImpl(string candidateString, IDataTypeSize? size)
+    protected override bool IsAcceptableAsTypeImpl(ReadOnlySpan<char> candidateString, IDataTypeSize? size)
     {
         // "Y" / "N" is boolean unless the settings say it can't
         if (!Settings.CharCanBeBoolean && SingleCharacter.IsMatch(candidateString))

--- a/TypeGuesser/Deciders/BoolTypeDecider.cs
+++ b/TypeGuesser/Deciders/BoolTypeDecider.cs
@@ -21,6 +21,8 @@ public sealed class BoolTypeDecider(CultureInfo culture):DecideTypesForStrings<b
     /// <inheritdoc />
     protected override object? ParseImpl(ReadOnlySpan<char> candidateString)
     {
+        if (bool.TryParse(candidateString, out var sysResult)) return sysResult;
+
         candidateString = StripWhitespace(candidateString);
 
         return candidateString.Length switch
@@ -53,13 +55,13 @@ public sealed class BoolTypeDecider(CultureInfo culture):DecideTypesForStrings<b
     /// <inheritdoc/>
     protected override bool IsAcceptableAsTypeImpl(ReadOnlySpan<char> candidateString,IDataTypeSize? size)
     {
-        candidateString = StripWhitespace(candidateString);
+        var strippedString = StripWhitespace(candidateString);
 
         // "Y" / "N" is boolean unless the settings say it can't
-        if (!Settings.CharCanBeBoolean && candidateString.Length == 1)
+        if (!Settings.CharCanBeBoolean && strippedString.Length == 1 && char.IsAsciiLetter(strippedString[0]))
             return false;
 
-        return candidateString.Length switch
+        return bool.TryParse(candidateString, out _) || candidateString.Length switch
         {
             1 => "1tTyYjJ0fFnN".IndexOf(candidateString[0]) != -1,
             2 => candidateString.Equals("ja",StringComparison.OrdinalIgnoreCase) ||

--- a/TypeGuesser/Deciders/BoolTypeDecider.cs
+++ b/TypeGuesser/Deciders/BoolTypeDecider.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Globalization;
-using System.Runtime.InteropServices;
 using System.Text.RegularExpressions;
-using TB.ComponentModel;
 
 namespace TypeGuesser.Deciders;
 

--- a/TypeGuesser/Deciders/DateTimeTypeDecider.cs
+++ b/TypeGuesser/Deciders/DateTimeTypeDecider.cs
@@ -157,7 +157,7 @@ public class DateTimeTypeDecider(CultureInfo cultureInfo) : DecideTypesForString
     }
 
     /// <inheritdoc/>
-    protected override object ParseImpl(string value)
+    protected override object ParseImpl(ReadOnlySpan<char> value)
     {
         // if user has specified a specific format that we are to use, use it
         if (Settings.ExplicitDateFormats != null)
@@ -165,7 +165,7 @@ public class DateTimeTypeDecider(CultureInfo cultureInfo) : DecideTypesForString
 
         // otherwise parse a value using any of the valid culture formats
         if (!TryBruteParse(value, out var dt))
-            throw new FormatException(string.Format(SR.DateTimeTypeDecider_ParseImpl_Could_not_parse___0___to_a_valid_DateTime, value));
+            throw new FormatException(string.Format(SR.DateTimeTypeDecider_ParseImpl_Could_not_parse___0___to_a_valid_DateTime, value.ToString()));
 
         return dt;
     }

--- a/TypeGuesser/Deciders/DecideTypesForStrings.cs
+++ b/TypeGuesser/Deciders/DecideTypesForStrings.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Globalization;
-using TB.ComponentModel;
 
 namespace TypeGuesser.Deciders;
 

--- a/TypeGuesser/Deciders/DecideTypesForStrings.cs
+++ b/TypeGuesser/Deciders/DecideTypesForStrings.cs
@@ -50,7 +50,7 @@ public abstract class DecideTypesForStrings<T> :IDecideTypesForStrings
     }
 
     /// <inheritdoc/>
-    public virtual bool IsAcceptableAsType(string candidateString,IDataTypeSize? size)
+    public virtual bool IsAcceptableAsType(ReadOnlySpan<char> candidateString, IDataTypeSize? size)
     {
         //we must preserve leading zeroes if it's not actually 0 -- if they have 010101 then we have to use string but if they have just 0 we can use decimal
         return !IDecideTypesForStrings.ZeroPrefixedNumber.IsMatch(candidateString) && IsAcceptableAsTypeImpl(candidateString, size);
@@ -61,10 +61,10 @@ public abstract class DecideTypesForStrings<T> :IDecideTypesForStrings
     /// </summary>
     /// <param name="candidateString"></param>
     /// <returns></returns>
-    protected bool IsExplicitDate(string candidateString)
+    protected bool IsExplicitDate(ReadOnlySpan<char> candidateString)
     {
         //if user has an explicit type format in mind and the candidate string is not null (which should hopefully be handled sensibly elsewhere)
-        if(Settings.ExplicitDateFormats != null && !string.IsNullOrWhiteSpace(candidateString))
+        if(Settings.ExplicitDateFormats != null && !candidateString.IsEmpty && !candidateString.IsWhiteSpace())
             return DateTime.TryParseExact(candidateString,Settings.ExplicitDateFormats,Culture,DateTimeStyles.None,out _);
 
         return false;
@@ -116,8 +116,8 @@ public abstract class DecideTypesForStrings<T> :IDecideTypesForStrings
     /// <param name="candidateString"></param>
     /// <param name="size"></param>
     /// <returns></returns>
-    protected virtual bool IsAcceptableAsTypeImpl(string candidateString,IDataTypeSize? size)
+    protected virtual bool IsAcceptableAsTypeImpl(ReadOnlySpan<char> candidateString, IDataTypeSize? size)
     {
-        return candidateString.IsConvertibleTo<T>(Culture);
+        return candidateString.ToString().IsConvertibleTo<T>(Culture);
     }
 }

--- a/TypeGuesser/Deciders/DecideTypesForStrings.cs
+++ b/TypeGuesser/Deciders/DecideTypesForStrings.cs
@@ -105,10 +105,7 @@ public abstract class DecideTypesForStrings<T> :IDecideTypesForStrings
     /// </summary>
     /// <param name="value"></param>
     /// <returns></returns>
-    protected virtual object? ParseImpl(string value)
-    {
-        return value.To<T>(Culture);
-    }
+    protected abstract object? ParseImpl(ReadOnlySpan<char> value);
 
     /// <summary>
     /// Returns true if the given <paramref name="candidateString"/> is compatible with the T Type of this decider.  This is the preferred method of overriding IsAcceptable.
@@ -116,8 +113,5 @@ public abstract class DecideTypesForStrings<T> :IDecideTypesForStrings
     /// <param name="candidateString"></param>
     /// <param name="size"></param>
     /// <returns></returns>
-    protected virtual bool IsAcceptableAsTypeImpl(ReadOnlySpan<char> candidateString, IDataTypeSize? size)
-    {
-        return candidateString.ToString().IsConvertibleTo<T>(Culture);
-    }
+    protected abstract bool IsAcceptableAsTypeImpl(ReadOnlySpan<char> candidateString, IDataTypeSize? size);
 }

--- a/TypeGuesser/Deciders/DecimalTypeDecider.cs
+++ b/TypeGuesser/Deciders/DecimalTypeDecider.cs
@@ -31,7 +31,7 @@ public sealed class DecimalTypeDecider : DecideTypesForStrings<decimal>
     }
 
     /// <inheritdoc />
-    protected override object? ParseImpl(ReadOnlySpan<char> value) => decimal.TryParse(value, Culture.NumberFormat, out var d) ? d : null;
+    protected override object? ParseImpl(ReadOnlySpan<char> value) => decimal.TryParse(value, NumberStyles.Any, Culture.NumberFormat, out var d) ? d : null;
 
     /// <inheritdoc/>
     protected override bool IsAcceptableAsTypeImpl(ReadOnlySpan<char> candidateString, IDataTypeSize? sizeRecord)

--- a/TypeGuesser/Deciders/DecimalTypeDecider.cs
+++ b/TypeGuesser/Deciders/DecimalTypeDecider.cs
@@ -1,4 +1,5 @@
-﻿using System.Data.SqlTypes;
+﻿using System;
+using System.Data.SqlTypes;
 using System.Globalization;
 using System.Linq;
 
@@ -30,7 +31,7 @@ public sealed class DecimalTypeDecider : DecideTypesForStrings<decimal>
     }
 
     /// <inheritdoc/>
-    protected override bool IsAcceptableAsTypeImpl(string candidateString,IDataTypeSize? sizeRecord)
+    protected override bool IsAcceptableAsTypeImpl(ReadOnlySpan<char> candidateString, IDataTypeSize? sizeRecord)
     {
         candidateString = TrimTrailingZeros(candidateString);
 
@@ -46,10 +47,10 @@ public sealed class DecimalTypeDecider : DecideTypesForStrings<decimal>
         return true;
     }
 
-    private string TrimTrailingZeros(string s)
+    private ReadOnlySpan<char> TrimTrailingZeros(ReadOnlySpan<char> s)
     {
         //don't trim 0 unless there's a decimal point e.g. don't trim from 1,000
-        if (!s.Contains(Culture.NumberFormat.NumberDecimalSeparator))
+        if (!s.Contains(_decimalIndicator))
             return s;
 
 

--- a/TypeGuesser/Deciders/DecimalTypeDecider.cs
+++ b/TypeGuesser/Deciders/DecimalTypeDecider.cs
@@ -2,7 +2,6 @@
 using System.Data.SqlTypes;
 using System.Globalization;
 using System.Linq;
-using TB.ComponentModel;
 
 namespace TypeGuesser.Deciders;
 

--- a/TypeGuesser/Deciders/DecimalTypeDecider.cs
+++ b/TypeGuesser/Deciders/DecimalTypeDecider.cs
@@ -2,6 +2,7 @@
 using System.Data.SqlTypes;
 using System.Globalization;
 using System.Linq;
+using TB.ComponentModel;
 
 namespace TypeGuesser.Deciders;
 
@@ -29,6 +30,9 @@ public sealed class DecimalTypeDecider : DecideTypesForStrings<decimal>
     {
         return new DecimalTypeDecider(culture);
     }
+
+    /// <inheritdoc />
+    protected override object? ParseImpl(ReadOnlySpan<char> value) => decimal.TryParse(value, Culture.NumberFormat, out var d) ? d : null;
 
     /// <inheritdoc/>
     protected override bool IsAcceptableAsTypeImpl(ReadOnlySpan<char> candidateString, IDataTypeSize? sizeRecord)

--- a/TypeGuesser/Deciders/IDecideTypesForStrings.cs
+++ b/TypeGuesser/Deciders/IDecideTypesForStrings.cs
@@ -54,9 +54,9 @@ public partial interface IDecideTypesForStrings
     /// </summary>
     /// <param name="candidateString">a string containing a value of unknown type (e.g. "fish" or "1")</param>
     /// <param name="size">The current size estimate of floating point numbers (or null if not appropriate).  This will be modified by the method
-    /// if appropriate to the data passed</param>
+    ///     if appropriate to the data passed</param>
     /// <returns>True if the <paramref name="candidateString"/> is a valid value for the <see cref="TypesSupported"/> by the decider</returns>
-    bool IsAcceptableAsType(string candidateString,IDataTypeSize? size);
+    bool IsAcceptableAsType(ReadOnlySpan<char> candidateString, IDataTypeSize? size);
 
     /// <summary>
     /// Converts the provided <paramref name="value"/> to an object of the Type modelled by this <see cref="IDecideTypesForStrings"/>.

--- a/TypeGuesser/Deciders/IDecideTypesForStrings.cs
+++ b/TypeGuesser/Deciders/IDecideTypesForStrings.cs
@@ -63,7 +63,7 @@ public partial interface IDecideTypesForStrings
     /// </summary>
     /// <param name="value"></param>
     /// <returns></returns>
-    object? Parse(string value);
+    object? Parse(ReadOnlySpan<char> value);
 
     /// <summary>
     /// Returns a new instance of this class with the same <see cref="Culture"/> and <see cref="Settings"/> etc

--- a/TypeGuesser/Deciders/IntTypeDecider.cs
+++ b/TypeGuesser/Deciders/IntTypeDecider.cs
@@ -1,4 +1,5 @@
-﻿using System.Globalization;
+﻿using System;
+using System.Globalization;
 using TB.ComponentModel;
 
 namespace TypeGuesser.Deciders;
@@ -19,12 +20,12 @@ public sealed class IntTypeDecider(CultureInfo culture) : DecideTypesForStrings<
     }
 
     /// <inheritdoc/>
-    protected override bool IsAcceptableAsTypeImpl(string candidateString, IDataTypeSize? sizeRecord)
+    protected override bool IsAcceptableAsTypeImpl(ReadOnlySpan<char> candidateString, IDataTypeSize? sizeRecord)
     {
         if(IsExplicitDate(candidateString))
             return false;
 
-        if (!candidateString.IsConvertibleTo(out int i, Culture))
+        if (!candidateString.ToString().IsConvertibleTo(out int i, Culture))
             return false;
 
         sizeRecord?.Size.IncreaseTo(i.ToString().Trim('-').Length,0);

--- a/TypeGuesser/Deciders/IntTypeDecider.cs
+++ b/TypeGuesser/Deciders/IntTypeDecider.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Globalization;
-using System.Reflection.Metadata.Ecma335;
-using TB.ComponentModel;
 
 namespace TypeGuesser.Deciders;
 

--- a/TypeGuesser/Deciders/IntTypeDecider.cs
+++ b/TypeGuesser/Deciders/IntTypeDecider.cs
@@ -19,7 +19,7 @@ public sealed class IntTypeDecider(CultureInfo culture) : DecideTypesForStrings<
     }
 
     /// <inheritdoc />
-    protected override object? ParseImpl(ReadOnlySpan<char> value) => int.TryParse(value, Culture.NumberFormat, out var i) ? i : null;
+    protected override object? ParseImpl(ReadOnlySpan<char> value) => int.TryParse(value, NumberStyles.Any, Culture.NumberFormat, out var i) ? i : null;
 
     /// <inheritdoc/>
     protected override bool IsAcceptableAsTypeImpl(ReadOnlySpan<char> candidateString, IDataTypeSize? sizeRecord)
@@ -27,7 +27,7 @@ public sealed class IntTypeDecider(CultureInfo culture) : DecideTypesForStrings<
         if(IsExplicitDate(candidateString))
             return false;
 
-        if (!int.TryParse(candidateString, Culture.NumberFormat, out var i)) return false;
+        if (!int.TryParse(candidateString, NumberStyles.Any, Culture.NumberFormat, out var i)) return false;
         //if (!candidateString.IsConvertibleTo(out int i, Culture)) return false;
 
         sizeRecord?.Size.IncreaseTo(i.ToString().Trim('-').Length,0);

--- a/TypeGuesser/Deciders/IntTypeDecider.cs
+++ b/TypeGuesser/Deciders/IntTypeDecider.cs
@@ -28,7 +28,6 @@ public sealed class IntTypeDecider(CultureInfo culture) : DecideTypesForStrings<
             return false;
 
         if (!int.TryParse(candidateString, NumberStyles.Any, Culture.NumberFormat, out var i)) return false;
-        //if (!candidateString.IsConvertibleTo(out int i, Culture)) return false;
 
         sizeRecord?.Size.IncreaseTo(i.ToString().Trim('-').Length,0);
         return true;

--- a/TypeGuesser/Deciders/IntTypeDecider.cs
+++ b/TypeGuesser/Deciders/IntTypeDecider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Globalization;
+using System.Reflection.Metadata.Ecma335;
 using TB.ComponentModel;
 
 namespace TypeGuesser.Deciders;
@@ -19,14 +20,17 @@ public sealed class IntTypeDecider(CultureInfo culture) : DecideTypesForStrings<
         return new IntTypeDecider(newCulture);
     }
 
+    /// <inheritdoc />
+    protected override object? ParseImpl(ReadOnlySpan<char> value) => int.TryParse(value, Culture.NumberFormat, out var i) ? i : null;
+
     /// <inheritdoc/>
     protected override bool IsAcceptableAsTypeImpl(ReadOnlySpan<char> candidateString, IDataTypeSize? sizeRecord)
     {
         if(IsExplicitDate(candidateString))
             return false;
 
-        if (!candidateString.ToString().IsConvertibleTo(out int i, Culture))
-            return false;
+        if (!int.TryParse(candidateString, Culture.NumberFormat, out var i)) return false;
+        //if (!candidateString.IsConvertibleTo(out int i, Culture)) return false;
 
         sizeRecord?.Size.IncreaseTo(i.ToString().Trim('-').Length,0);
         return true;

--- a/TypeGuesser/Deciders/NeverGuessedTypeDecider.cs
+++ b/TypeGuesser/Deciders/NeverGuessedTypeDecider.cs
@@ -19,7 +19,7 @@ public sealed class NeverGuessTheseTypeDecider(CultureInfo culture) : DecideType
     protected override object ParseImpl(string value) => throw new NotSupportedException();
 
     /// <inheritdoc/>
-    protected override bool IsAcceptableAsTypeImpl(string candidateString, IDataTypeSize? sizeRecord) =>
+    protected override bool IsAcceptableAsTypeImpl(ReadOnlySpan<char> candidateString, IDataTypeSize? sizeRecord) =>
         //strings should never be interpreted as byte arrays
         false;
 }

--- a/TypeGuesser/Deciders/NeverGuessedTypeDecider.cs
+++ b/TypeGuesser/Deciders/NeverGuessedTypeDecider.cs
@@ -16,7 +16,7 @@ public sealed class NeverGuessTheseTypeDecider(CultureInfo culture) : DecideType
     protected override IDecideTypesForStrings CloneImpl(CultureInfo newCulture) => new NeverGuessTheseTypeDecider(newCulture);
 
     /// <inheritdoc/>
-    protected override object ParseImpl(string value) => throw new NotSupportedException();
+    protected override object ParseImpl(ReadOnlySpan<char> _) => throw new NotSupportedException();
 
     /// <inheritdoc/>
     protected override bool IsAcceptableAsTypeImpl(ReadOnlySpan<char> candidateString, IDataTypeSize? sizeRecord) =>

--- a/TypeGuesser/Deciders/TimeSpanTypeDecider.cs
+++ b/TypeGuesser/Deciders/TimeSpanTypeDecider.cs
@@ -19,7 +19,7 @@ public sealed class TimeSpanTypeDecider(CultureInfo culture) : DecideTypesForStr
     protected override object ParseImpl(string value) => DateTime.Parse(value).TimeOfDay;
 
     /// <inheritdoc/>
-    protected override bool IsAcceptableAsTypeImpl(string candidateString, IDataTypeSize? sizeRecord)
+    protected override bool IsAcceptableAsTypeImpl(ReadOnlySpan<char> candidateString, IDataTypeSize? sizeRecord)
     {
         try
         {

--- a/TypeGuesser/Deciders/TimeSpanTypeDecider.cs
+++ b/TypeGuesser/Deciders/TimeSpanTypeDecider.cs
@@ -16,7 +16,7 @@ public sealed class TimeSpanTypeDecider(CultureInfo culture) : DecideTypesForStr
     protected override IDecideTypesForStrings CloneImpl(CultureInfo newCulture) => new TimeSpanTypeDecider(newCulture);
 
     /// <inheritdoc/>
-    protected override object ParseImpl(string value) => DateTime.Parse(value).TimeOfDay;
+    protected override object ParseImpl(ReadOnlySpan<char> value) => DateTime.Parse(value).TimeOfDay;
 
     /// <inheritdoc/>
     protected override bool IsAcceptableAsTypeImpl(ReadOnlySpan<char> candidateString, IDataTypeSize? sizeRecord)

--- a/TypeGuesser/Guesser.cs
+++ b/TypeGuesser/Guesser.cs
@@ -25,7 +25,7 @@ public class Guesser
 
     /// <summary>
     /// Normally when measuring the lengths of strings something like "It’s" would be 4 but for Oracle it needs extra width.  If this is
-    /// non zero then when <see cref="AdjustToCompensateForValue(object)"/> is a string then any non standard characters will have this number
+    /// non zero then when <see cref="AdjustToCompensateForValue(in object)"/> is a string then any non standard characters will have this number
     /// added to the length predicted.
     /// </summary>
     public int ExtraLengthPerNonAsciiCharacter { get; init; }
@@ -110,17 +110,18 @@ public class Guesser
     }
 
     /// <summary>
-    /// <para>Adjusts the current <see cref="Guess"/> based on the <paramref name="o"/>.  All calls to this method for a given <see cref="Guesser"/>
+    /// <para>Adjusts the current <see cref="Guess"/> based on the <paramref name="originalO"/>.  All calls to this method for a given <see cref="Guesser"/>
     /// instance must be of the same Type e.g. string.  If you pass a hard Typed value in (e.g. int) then the <see cref="Guess"/> will change
     /// to the Type of the object but it will still calculate length/digits.
     /// </para>
     /// 
     /// <para>Passing null / <see cref="DBNull.Value"/> is always allowed and never changes the <see cref="Guess"/></para>
     /// </summary>
-    /// <exception cref="MixedTypingException">Thrown if you mix strings with hard Typed objects when supplying <paramref name="o"/></exception>
-    /// <param name="o"></param>
-    public void AdjustToCompensateForValue(object? o)
+    /// <exception cref="MixedTypingException">Thrown if you mix strings with hard Typed objects when supplying <paramref name="originalO"/></exception>
+    /// <param name="originalO"></param>
+    public void AdjustToCompensateForValue(in object? originalO)
     {
+        var o = originalO;
         while (true)
         {
             if (o == null) return;

--- a/TypeGuesser/Guesser.cs
+++ b/TypeGuesser/Guesser.cs
@@ -122,12 +122,10 @@ public class Guesser
     /// <param name="o"></param>
     public void AdjustToCompensateForValue(object? o)
     {
+        if (o == null || o == DBNull.Value) return;
+
         while (true)
         {
-            if (o == null) return;
-
-            if (o == DBNull.Value) return;
-
             //if we have previously seen a hard typed value then we can't just change datatypes to something else!
             if (IsPrimedWithBonafideType && Guess.CSharpType != o.GetType())
                 throw new MixedTypingException(string.Format(

--- a/TypeGuesser/Guesser.cs
+++ b/TypeGuesser/Guesser.cs
@@ -188,6 +188,22 @@ public class Guesser
 
     private int GetStringLength(ReadOnlySpan<char> oToString)
     {
+        // Fast path: if we don't need extra space for unicode, we only care if we hit the first Unicode char:
+        if (ExtraLengthPerNonAsciiCharacter == 0)
+        {
+            // Already seen Unicode? No need to check!
+            if (Guess.Unicode) return oToString.Length;
+
+            foreach (var c in oToString)
+            {
+                if (char.IsAscii(c)) continue;
+
+                Guess.Unicode = true;
+                return oToString.Length;
+            }
+            return oToString.Length;
+        }
+
         var nonAscii = 0;
         foreach (var c in oToString)
         {

--- a/TypeGuesser/TypeGuesser.csproj
+++ b/TypeGuesser/TypeGuesser.csproj
@@ -20,18 +20,8 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<None Include="..\README.md" Pack="true" PackagePath="\"/>
+		<None Include="..\README.md" Pack="true" PackagePath="\" />
 		<Compile Include="..\SharedAssemblyInfo.cs" Link="SharedAssemblyInfo.cs" />
-	</ItemGroup>
-
-	<ItemGroup>
-		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0">
-			<IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-			<PrivateAssets>all</PrivateAssets>
-		</PackageReference>
-		<PackageReference Include="UniversalTypeConverter" Version="2.6.0">
-			<PrivateAssets>None</PrivateAssets>
-		</PackageReference>
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Do string parsing using Spans rather than string objects (makes `IsAcceptableAsType` method c 33% faster, eliminates an external dependency.)

Also exclude `.g.cs` (compiler-generated source) from CodeQL analysis, since we don't maintain it ourselves anyway.